### PR TITLE
DO NOT MERGE - sendResponse refactor proposal

### DIFF
--- a/src/adapters/http/sendNotification/router.ts
+++ b/src/adapters/http/sendNotification/router.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import * as f from 'fp-ts/function';
 import * as E from 'fp-ts/Either';
 import * as TE from 'fp-ts/TaskEither';
+import { lookup } from 'fp-ts/lib/ReadonlyRecord';
 import { HTTP_STATUS, sendError, sendSucces } from '../utils';
 import { ApiKey } from '../../../generated/definitions/ApiKey';
 import { NewNotificationRequest } from '../../../generated/definitions/NewNotificationRequest';
@@ -16,7 +17,7 @@ const handler =
       E.ap(NewNotificationRequest.decode(req.body)),
       E.fold(
         sendError('Input error', HTTP_STATUS[400])(res),
-        TE.fold(sendError('Input error', HTTP_STATUS[400])(res), sendSucces(HTTP_STATUS[200])(res))
+        TE.fold(sendError('Input error', HTTP_STATUS[400])(res), (_) => sendSucces(HTTP_STATUS[202])(res)(_.returned))
       )
     )();
 

--- a/src/adapters/http/sendNotification/router.ts
+++ b/src/adapters/http/sendNotification/router.ts
@@ -2,7 +2,6 @@ import express from 'express';
 import * as f from 'fp-ts/function';
 import * as E from 'fp-ts/Either';
 import * as TE from 'fp-ts/TaskEither';
-import { lookup } from 'fp-ts/lib/ReadonlyRecord';
 import { HTTP_STATUS, sendError, sendSucces } from '../utils';
 import { ApiKey } from '../../../generated/definitions/ApiKey';
 import { NewNotificationRequest } from '../../../generated/definitions/NewNotificationRequest';

--- a/src/adapters/http/utils.ts
+++ b/src/adapters/http/utils.ts
@@ -1,37 +1,30 @@
-import express from 'express';
-import * as t from 'io-ts';
-import * as TE from 'fp-ts/TaskEither';
-import * as E from 'fp-ts/Either';
 import * as PR from 'io-ts/PathReporter';
-import { pipe, unsafeCoerce } from 'fp-ts/function';
+import * as T from 'fp-ts/Task';
+import * as t from 'io-ts';
+import { Response } from 'express';
 import { flow } from 'fp-ts/function';
+import { unsafeCoerce } from 'fp-ts/function';
 import { Problem } from '../../generated/definitions/Problem';
 
-export const makeAPIProblem =
-  (status: number, message: string) =>
-  (errors: t.Errors | undefined): Problem => ({
+export const toProblem =
+  (message: string, status: Problem['status']) =>
+  (errors?: t.Errors | Error): Problem => ({
     type: `https://www.webfx.com/web-development/glossary/http-status-codes/what-is-a-${status}-status-code/`,
-    status: unsafeCoerce(status), // TODO Figure why without the cast this doesn't compile
+    status,
     title: message,
-    detail: errors ? PR.failure(errors) : message,
+    detail: errors ? (errors instanceof Error ? errors.message : PR.failure(errors)) : message,
     errors: [],
   });
 
-export const sendResponse =
-  (res: express.Response) =>
-  <T0, T1>(left: (t0: T0) => express.Response, right: (t1: T1) => express.Response) =>
-  (arg: E.Either<t.Errors, TE.TaskEither<T0, T1>>): Promise<express.Response> =>
-    pipe(
-      E.mapLeft(makeAPIProblem(400, 'Input Error'))(arg),
-      E.fold(
-        (invalidInput) => Promise.resolve(res.status(400).send(invalidInput)),
-        flow(
-          TE.fold(
-            (l) => TE.of(left(l)),
-            (r) => TE.of(right(r))
-          ),
-          TE.toUnion,
-          (te) => te()
-        )
-      )
-    );
+export const sendError = (message: string, status: Problem['status']) => (res: Response) =>
+  flow(toProblem(message, status), res.status(status).send, Promise.resolve, T.of);
+
+export const sendSucces = (status: Problem['status']) => (res: Response) =>
+  flow(res.status(status).send, Promise.resolve, T.of);
+
+// TODO: find a smarter way to do this
+export const HTTP_STATUS: Record<number, Problem['status']> = {
+  200: unsafeCoerce(200),
+  400: unsafeCoerce(400),
+  500: unsafeCoerce(500),
+};


### PR DESCRIPTION
Proposal to refactor sendResponse in a simpler way.

The ratio behind this changes:
1. currently, `sendResponse` is a glorified either folding method: the branching should be implemented by the caller, not encpasulated into a method
1. this is doable using a simple rule: never take monadic structures as input
1. when you do that, the pipeline becomes straightforward to read since everybody knows what `fold` does but nobody knows what `sendResponse` does so you have to inspect the implementation to grasp the monadic structure manipulation
1. there's a [bunch of code that just does nothing](https://github.com/pagopa/pn-local-emulator-poc/blob/main/src/adapters/http/utils.ts#L28)