### PR TITLE
[VL-61] Strip null fields

### DIFF
--- a/src/adapters/http/Handler.ts
+++ b/src/adapters/http/Handler.ts
@@ -21,15 +21,14 @@ export const toExpressHandler =
 /**
  * Return an object filtering out keys that point to null values.
  */
-export const removeNullValues = <T, K extends keyof T>(obj: T): T => {
-  const keys = Object.keys(obj);
-  return keys.reduce((acc, key) => {
-    const value = obj[key as K];
-    return value !== null
-      ? {
-          ...acc,
-          [key]: isObject(value) ? removeNullValues(value) : value,
-        }
-      : acc;
-  }, {} as T);
+export const removeNullValues = <T, K extends keyof T>(input: T): T => {
+  if (Array.isArray(input)) {
+    return input.map(removeNullValues) as T;
+  } else if (isObject(input)) {
+    return Object.keys(input)
+      .filter((key) => input[key as K] !== null)
+      .reduce((acc, k) => ({ ...acc, [k]: removeNullValues(input[k]) }), {} as T);
+  } else {
+    return input;
+  }
 };

--- a/src/adapters/http/Handler.ts
+++ b/src/adapters/http/Handler.ts
@@ -23,12 +23,7 @@ export const toExpressHandler =
  */
 export const removeNullValues = <T, K extends keyof T>(input: T): T => {
   if (Array.isArray(input)) {
-    return (
-      input
-        .map(removeNullValues)
-        // Remove object without keys within the array
-        .filter((elem) => (isObject(elem) ? Object.keys(elem).length > 0 : elem)) as T
-    );
+    return input.map(removeNullValues) as T;
   } else if (isObject(input)) {
     return Object.keys(input)
       .filter((key) => input[key as K] !== null)

--- a/src/adapters/http/Handler.ts
+++ b/src/adapters/http/Handler.ts
@@ -23,7 +23,12 @@ export const toExpressHandler =
  */
 export const removeNullValues = <T, K extends keyof T>(input: T): T => {
   if (Array.isArray(input)) {
-    return input.map(removeNullValues) as T;
+    return (
+      input
+        .map(removeNullValues)
+        // Remove object without keys within the array
+        .filter((elem) => (isObject(elem) ? Object.keys(elem).length > 0 : elem)) as T
+    );
   } else if (isObject(input)) {
     return Object.keys(input)
       .filter((key) => input[key as K] !== null)

--- a/src/adapters/http/Handler.ts
+++ b/src/adapters/http/Handler.ts
@@ -3,8 +3,8 @@ import * as t from 'io-ts';
 import * as T from 'fp-ts/Task';
 import * as E from 'fp-ts/Either';
 import { pipe } from 'fp-ts/function';
-import * as Problem from './Problem';
 import { isObject } from '@pagopa/ts-commons/lib/types';
+import * as Problem from './Problem';
 
 export type Handler = (req: express.Request, res: express.Response) => t.Validation<T.Task<express.Response>>;
 

--- a/src/adapters/http/Handler.ts
+++ b/src/adapters/http/Handler.ts
@@ -21,14 +21,14 @@ export const toExpressHandler =
 /**
  * Return an object filtering out keys that point to null values.
  */
-export const withoutNullValues = <T, K extends keyof T>(obj: T): T => {
+export const removeNullValues = <T, K extends keyof T>(obj: T): T => {
   const keys = Object.keys(obj);
   return keys.reduce((acc, key) => {
     const value = obj[key as K];
     return value !== null
       ? {
           ...acc,
-          [key]: isObject(value) ? withoutNullValues(value) : value,
+          [key]: isObject(value) ? removeNullValues(value) : value,
         }
       : acc;
   }, {} as T);

--- a/src/adapters/http/Handler.ts
+++ b/src/adapters/http/Handler.ts
@@ -4,6 +4,7 @@ import * as T from 'fp-ts/Task';
 import * as E from 'fp-ts/Either';
 import { pipe } from 'fp-ts/function';
 import * as Problem from './Problem';
+import { isObject } from '@pagopa/ts-commons/lib/types';
 
 export type Handler = (req: express.Request, res: express.Response) => t.Validation<T.Task<express.Response>>;
 
@@ -16,3 +17,19 @@ export const toExpressHandler =
       E.toUnion,
       (task) => task()
     );
+
+/**
+ * Return an object filtering out keys that point to null values.
+ */
+export const withoutNullValues = <T, K extends keyof T>(obj: T): T => {
+  const keys = Object.keys(obj);
+  return keys.reduce((acc, key) => {
+    const value = obj[key as K];
+    return value !== null
+      ? {
+          ...acc,
+          [key]: isObject(value) ? withoutNullValues(value) : value,
+        }
+      : acc;
+  }, {} as T);
+};

--- a/src/adapters/http/__tests__/Handler.test.ts
+++ b/src/adapters/http/__tests__/Handler.test.ts
@@ -8,14 +8,14 @@ describe('removeNullValues', () => {
       d: [1, 2],
       e: null,
     },
-    f: [{ g: null, h: 1 }],
+    f: [{ g: 1 }, { h: null }],
   };
   const expected = {
     a: 1,
     c: {
       d: [1, 2],
     },
-    f: [{ h: 1 }],
+    f: [{ g: 1 }],
   };
 
   it('should filter out null properties recursively', async () => {
@@ -25,6 +25,6 @@ describe('removeNullValues', () => {
 
   it('should filter out null properties recursively - input is an array', async () => {
     const actual = removeNullValues([inputObject]);
-    expect(actual).toStrictEqual(expected);
+    expect(actual).toStrictEqual([expected]);
   });
 });

--- a/src/adapters/http/__tests__/Handler.test.ts
+++ b/src/adapters/http/__tests__/Handler.test.ts
@@ -1,23 +1,30 @@
 import { removeNullValues } from '../Handler';
 
-describe('withoutNullValues', () => {
-  it('should filter out null properties recursively', async () => {
-    const obj = {
-      a: 1,
-      b: null,
-      c: {
-        d: [1, 2],
-        e: null,
-      },
-    };
-    const actual = removeNullValues(obj);
-    const expected = {
-      a: 1,
-      c: {
-        d: [1, 2],
-      },
-    };
+describe('removeNullValues', () => {
+  const inputObject = {
+    a: 1,
+    b: null,
+    c: {
+      d: [1, 2],
+      e: null,
+    },
+    f: [{ g: null, h: 1 }],
+  };
+  const expected = {
+    a: 1,
+    c: {
+      d: [1, 2],
+    },
+    f: [{ h: 1 }],
+  };
 
+  it('should filter out null properties recursively', async () => {
+    const actual = removeNullValues(inputObject);
+    expect(actual).toStrictEqual(expected);
+  });
+
+  it('should filter out null properties recursively - input is an array', async () => {
+    const actual = removeNullValues([inputObject]);
     expect(actual).toStrictEqual(expected);
   });
 });

--- a/src/adapters/http/__tests__/Handler.test.ts
+++ b/src/adapters/http/__tests__/Handler.test.ts
@@ -8,14 +8,14 @@ describe('removeNullValues', () => {
       d: [1, 2],
       e: null,
     },
-    f: [{ g: 1 }, { h: null }],
+    f: [{ g: 1, h: null }, { i: null }],
   };
   const expected = {
     a: 1,
     c: {
       d: [1, 2],
     },
-    f: [{ g: 1 }],
+    f: [{ g: 1 }, {}],
   };
 
   it('should filter out null properties recursively', async () => {

--- a/src/adapters/http/__tests__/Handler.test.ts
+++ b/src/adapters/http/__tests__/Handler.test.ts
@@ -1,6 +1,6 @@
-import { withoutNullValues } from '../Handler';
+import { removeNullValues } from '../Handler';
 
-describe('Handler', () => {
+describe('withoutNullValues', () => {
   it('should filter out null properties recursively', async () => {
     const obj = {
       a: 1,
@@ -10,7 +10,7 @@ describe('Handler', () => {
         e: null,
       },
     };
-    const actual = withoutNullValues(obj);
+    const actual = removeNullValues(obj);
     const expected = {
       a: 1,
       c: {

--- a/src/adapters/http/__tests__/Handler.test.ts
+++ b/src/adapters/http/__tests__/Handler.test.ts
@@ -1,0 +1,23 @@
+import { withoutNullValues } from '../Handler';
+
+describe('Handler', () => {
+  it('should filter out null properties recursively', async () => {
+    const obj = {
+      a: 1,
+      b: null,
+      c: {
+        d: [1, 2],
+        e: null,
+      },
+    };
+    const actual = withoutNullValues(obj);
+    const expected = {
+      a: 1,
+      c: {
+        d: [1, 2],
+      },
+    };
+
+    expect(actual).toStrictEqual(expected);
+  });
+});

--- a/src/adapters/http/sendNotification/router.ts
+++ b/src/adapters/http/sendNotification/router.ts
@@ -7,7 +7,7 @@ import * as Problem from '../Problem';
 import { ApiKey } from '../../../generated/definitions/ApiKey';
 import { NewNotificationRequest } from '../../../generated/definitions/NewNotificationRequest';
 import { SendNotificationUseCase } from '../../../useCases/SendNotificationUseCase';
-import { Handler, toExpressHandler } from '../Handler';
+import {Handler, toExpressHandler, withoutNullValues} from '../Handler';
 
 const handler =
   (sendNotificationUseCase: SendNotificationUseCase): Handler =>
@@ -15,7 +15,7 @@ const handler =
     pipe(
       E.of(sendNotificationUseCase),
       E.ap(ApiKey.decode(req.headers['x-api-key'])),
-      E.ap(NewNotificationRequest.decode(req.body)),
+      E.ap(NewNotificationRequest.decode(withoutNullValues(req.body))),
       // Create response
       E.map(
         TE.fold(

--- a/src/adapters/http/sendNotification/router.ts
+++ b/src/adapters/http/sendNotification/router.ts
@@ -7,7 +7,7 @@ import * as Problem from '../Problem';
 import { ApiKey } from '../../../generated/definitions/ApiKey';
 import { NewNotificationRequest } from '../../../generated/definitions/NewNotificationRequest';
 import { SendNotificationUseCase } from '../../../useCases/SendNotificationUseCase';
-import { Handler, toExpressHandler, withoutNullValues } from '../Handler';
+import { Handler, toExpressHandler, removeNullValues } from '../Handler';
 
 const handler =
   (sendNotificationUseCase: SendNotificationUseCase): Handler =>
@@ -15,7 +15,7 @@ const handler =
     pipe(
       E.of(sendNotificationUseCase),
       E.ap(ApiKey.decode(req.headers['x-api-key'])),
-      E.ap(NewNotificationRequest.decode(withoutNullValues(req.body))),
+      E.ap(NewNotificationRequest.decode(removeNullValues(req.body))),
       // Create response
       E.map(
         TE.fold(

--- a/src/adapters/http/sendNotification/router.ts
+++ b/src/adapters/http/sendNotification/router.ts
@@ -7,7 +7,7 @@ import * as Problem from '../Problem';
 import { ApiKey } from '../../../generated/definitions/ApiKey';
 import { NewNotificationRequest } from '../../../generated/definitions/NewNotificationRequest';
 import { SendNotificationUseCase } from '../../../useCases/SendNotificationUseCase';
-import {Handler, toExpressHandler, withoutNullValues} from '../Handler';
+import { Handler, toExpressHandler, withoutNullValues } from '../Handler';
 
 const handler =
   (sendNotificationUseCase: SendNotificationUseCase): Handler =>


### PR DESCRIPTION
This project's scope is to emulate the Piattaforma Notifiche (PN) software. Since PN does not include null fields (the object mapper used [has been instructed as follow](https://github.com/pagopa/pn-delivery/blob/803daa4e0dc135867b8f61d179cb45e7bc4edc1a/src/main/resources/application.properties#L37)), then the behavior of this tool must be the same, which means that we have to accept null values, but we have to ignore them.

#### List of Changes
Add a method that removes keys with a null value from a JSON.
It replicates what has been done into [io-ts-commons repository](https://github.com/pagopa/io-ts-commons/blob/622a7585b2e3f3bacf872f52c698bb41c7fb8992/src/types.ts#L128) changing the condition.

If necessary, we can evaluate making a PR to that repo as well and import the method from `io-ts-commons`.

#### Motivation and Context
A client may call PN (and as a consequence, may call this tool too) passing a JSON with `null` value of some keys (e.g. `{"a": 1, b: null}`).

#### Types of changes
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)